### PR TITLE
Prevent buttons showing up when adding an object.

### DIFF
--- a/fsm_admin2/admin.py
+++ b/fsm_admin2/admin.py
@@ -116,7 +116,7 @@ def _get_transition_form(transition):
 
 def _get_display_func(field_name):
     def display_func(self, obj=None):
-        if obj is None:
+        if obj is None or (obj is not None and not obj.pk):
             return ''
         transitions = getattr(obj, f'get_available_user_{field_name}_transitions')(self.request.user)
 


### PR DESCRIPTION
I'm not sure if this is how it should always be in Django, but at least in some cases, I get a blank object when the form is created, which most certainly is not `None`.

Not sure which is the best way to check for this or if this is even a universal fix, but submitting it for your attention anyway.